### PR TITLE
Fix group count for DISTINCT queries.

### DIFF
--- a/lib/active_record_group_count/scope.rb
+++ b/lib/active_record_group_count/scope.rb
@@ -4,7 +4,7 @@ module ActiveRecordGroupCount
 
     module ExtensionMethods
       def count(*args)
-        scope = except(:select).select("1")
+        scope = except(:select).except(:distinct).select("1")
         scope_sql = if scope.klass.connection.respond_to?(:unprepared_statement)
           scope.klass.connection.unprepared_statement { scope.to_sql }
         else


### PR DESCRIPTION
If the query happens to contain a `SELECT DISTINCT`, it would be changed to "SELECT DISTINCT 1" by the extension and therefore the query would always return only one row.